### PR TITLE
Changes to Gulps own implementation of code completion.

### DIFF
--- a/gulp-autocompletion.zsh
+++ b/gulp-autocompletion.zsh
@@ -2,12 +2,12 @@
 
 #
 # gulp-autocompletion-zsh
-# 
+#
 # Autocompletion for your gulp.js tasks
 #
 # Copyright(c) 2014 André König <andre.koenig@posteo.de>
 # MIT Licensed
-# 
+#
 
 #
 # André König
@@ -15,15 +15,6 @@
 # Twitter: https://twitter.com/caiifr
 #
 
-#
-# Grabs all available tasks from the `gulpfile.js`
-# in the current directory.
-#
-function $$gulp_completion() {
-    compls=$(grep -Eo "gulp.task\(('(([a-zA-Z0-9]|-)*)',)" gulpfile.js 2>/dev/null | grep -Eo "'(([a-zA-Z0-9]|-)*)'" | sed s/"'"//g | sort)
-
-    completions=(${=compls})
-    compadd -- $completions
-}
-
-compdef $$gulp_completion gulp
+# Uses gulps completion. See
+# https://github.com/gulpjs/gulp/tree/master/completion
+eval "$(gulp --completion=zsh 2>/dev/null)"


### PR DESCRIPTION
Hi!

There is already an implementation of this within Gulp. But I think adding this wrapper to the oh-my-zsh repo as with npm is a good idea.

I've changed this plugin to use the Gulp implementation with "gulp --completion". The current gulp implementation is somewhat similar to your own, but as of 3.7.0 they change to use a new "--tasks-simple" flag, which should be quicker I figure.
