### PR TITLE
Support for task names with colons (:)

### DIFF
--- a/gulp-autocompletion.zsh
+++ b/gulp-autocompletion.zsh
@@ -20,7 +20,7 @@
 # in the current directory.
 #
 function $$gulp_completion() {
-    compls=$(grep -Eo "gulp.task\(('(([a-zA-Z0-9]|-)*)',)" gulpfile.js 2>/dev/null | grep -Eo "'(([a-zA-Z0-9]|-)*)'" | sed s/"'"//g | sort)
+    compls=$(grep -Eo "gulp.task\(('(([a-zA-Z0-9:]|-)*)',)" gulpfile.js 2>/dev/null | grep -Eo "'(([a-zA-Z0-9:]|-)*)'" | sed s/"'"//g | sort)
 
     completions=(${=compls})
     compadd -- $completions


### PR DESCRIPTION
A quick fix to support gulp task names with colons, for example `less:dev`.