### PR TITLE
use gulp --tasks-simple for proper list of tasks

### DIFF
--- a/gulp.plugin.zsh
+++ b/gulp.plugin.zsh
@@ -18,7 +18,7 @@
 # `gulpfile.coffee` in the current directory.
 #
 function tasks () {
-    compls=$(grep -Eho "gulp\.task[^,]*" gulpfile.* 2>/dev/null | sed s/\"/\'/g | cut -d "'" -f 2 | sort)
+    compls=$(gulp --tasks-simple)
 
     completions=(${=compls})
     compadd -- $completions


### PR DESCRIPTION
This is the better way to get the list of tasks.

It should possibly check for the local version of gulp, but people generally install gulp globally anyway, so it shouldn't matter.
